### PR TITLE
documentation updated: to run the docker image by name, assign a name…

### DIFF
--- a/README
+++ b/README
@@ -8,7 +8,7 @@ The project's source code has a lot of dependencies and requires a lot of tediou
 
 To build an image go to the Dockerfile dir and do:
 
-    docker build .
+    docker build -t liquid-feedback .
     
 To run the server do:
 


### PR DESCRIPTION
… to it first

At least for the very first time when you run "docker build ." you need to specify a name. If not, the second command "docker run liquid-feedback" will not find the image.
```
$ docker build .
[...]
Successfully built 91c77638f677
```
```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
<none>              <none>              91c77638f677        5 minutes ago       644MB
debian              jessie              0a374bb127cf        2 weeks ago         123MB
hello-world         latest              05a3bd381fc2        2 weeks ago         1.84kB
```

```
$ docker run liquid-feedback
Unable to find image 'liquid-feedback:latest' locally
docker: Error response from daemon: pull access denied for liquid-feedback, repository does not exist or may require 'docker login'.
See 'docker run --help'.
```
